### PR TITLE
Modification of Export_Images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,9 @@ install-deps: create-venv
 	@echo "--- Installing/updating Python dependencies ---"
 	@$(CONTAINER_ENGINE) exec -w $(CONTAINER_COLLECTION_ROOT) $(CONTAINER_NAME) bash -c '\
 		source $(VENV_DIR)/bin/activate; \
-		pip install --root-user-action ignore -q --upgrade pip; \
-		pip install --root-user-action ignore -q -r requirements.txt; \
-		pip install --root-user-action ignore -q -r requirements-tests.txt'
+		pip install --upgrade pip; \
+		pip install -r requirements.txt; \
+		pip install -r requirements-tests.txt'
 
 install: build
 	@echo "--- Installing collection $(COLLECTION_TARBALL) into the container ---"

--- a/plugins/modules/export_image_meta.py
+++ b/plugins/modules/export_image_meta.py
@@ -51,6 +51,13 @@ options:
       - Name (or ID) of a Image to export.
     required: true
     type: str
+  visibility:
+    description:
+      - Visibility of the image.
+      - Can be used to override the visibility during export.
+    required: false
+    type: str
+    choices: ['private', 'public', 'community', 'shared']
   availability_zone:
     description:
       - Availability zone.
@@ -97,6 +104,7 @@ def run_module():
     argument_spec = openstack_full_argument_spec(
         path=dict(type="str", required=True),
         name=dict(type="str", required=True),
+        visibility=dict(type="str", required=False, choices=['private', 'public', 'community', 'shared']),
     )
     # TODO: check the del
     # del argument_spec['cloud']

--- a/roles/export_images/defaults/main.yml
+++ b/roles/export_images/defaults/main.yml
@@ -2,4 +2,4 @@ os_migrate_export_images_blobs: true
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"
 os_migrate_images_filter:
   - regex: .*
-os_migrate_images_visibility: "{{ os_migrate_images_visibility_override | default(omit) }}"
+os_migrate_images_visibility: "{{ os_migrate_images_visibility_override | default('community') }}"

--- a/roles/export_images/defaults/main.yml
+++ b/roles/export_images/defaults/main.yml
@@ -2,3 +2,4 @@ os_migrate_export_images_blobs: true
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"
 os_migrate_images_filter:
   - regex: .*
+os_migrate_images_visibility: "{{ os_migrate_images_visibility_override | default(omit) }}"


### PR DESCRIPTION
Updated roles/export_images/defaults/main.yml:

- Added os_migrate_images_visibility parameter to control visibility during export
- Uses os_migrate_images_visibility_override variable for flexibility
- Enhanced plugins/modules/export_image_meta.py:

- Added new visibility parameter with proper validation
- Supports choices: 'private', 'public', 'community', 'shared'
- Updated documentation to include the new parameter