### PR TITLE
Preserve UUID and tune image import

### DIFF
--- a/roles/export_images/defaults/main.yml
+++ b/roles/export_images/defaults/main.yml
@@ -1,5 +1,6 @@
 os_migrate_export_images_blobs: true
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"
 os_migrate_images_filter:
-  - regex: .* 
+  - regex: .*
+# Set to false to allow destination cloud to generate new image IDs
 os_migrate_preserve_image_uuid: true

--- a/roles/export_images/defaults/main.yml
+++ b/roles/export_images/defaults/main.yml
@@ -1,4 +1,5 @@
 os_migrate_export_images_blobs: true
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"
 os_migrate_images_filter:
-  - regex: .*
+  - regex: .* 
+os_migrate_preserve_image_uuid: true

--- a/roles/export_images/tasks/main.yml
+++ b/roles/export_images/tasks/main.yml
@@ -42,6 +42,7 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    preserve_uuid: "{{ os_migrate_preserve_image_uuid }}"
   loop: "{{ export_images_ids_names }}"
 
 - name: make sure image blob dir exists


### PR DESCRIPTION
## Summary
- keep image UUID in exported parameters and reuse it on import
- default exported images to community visibility and drop transient glance properties
- ensure image import copies to all glance stores

## Testing
- `make tests` *(fails: podman: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce2dbdf748329be31f6d3afcf87c3